### PR TITLE
MediaIndexer to extract the file size

### DIFF
--- a/src/MetadataExtractor.cc
+++ b/src/MetadataExtractor.cc
@@ -193,8 +193,10 @@ MediaFile MetadataExtractor::extract(const DetectedFile &d)
     mf.setCreatedTime(time(NULL));
 
     struct stat st;
-    if (stat(d.path.c_str(), &st) == 0)
+    if (stat(d.path.c_str(), &st) == 0) {
         mf.setModifiedTime(st.st_mtime);
+        mf.setSize(st.st_size);
+    }
 
     if (d.type == AudioMedia)
         extractForAudio(mf, d);


### PR DESCRIPTION
- During file meta data extraction, extract the file size
- Tested on the Emulator after this change. The luna-send command started returning a value for size attribute 

`luna-send -n 1 -a org.webosports.app.pdf luna://com.palm.db/find  '{"query":{"from":"com.palm.media.misc.file:1","where":[]}}`

`{"returnValue":true,"results":[{"_id":"J8Q6XgJLdzZ","_kind":"com.palm.media.misc.file:1","_rev":315,"createdTime":1417736369,"extension":"pdf","modifiedTime":1417736369,"name":"compressed.tracemonkey-pldi-09.pdf","path":"/media/internal/compressed.tracemonkey-pldi-09.pdf","searchKey":"compressed.tracemonkey-pldi-09.pdf","size":1016315},{"_id":"J8Q6Xh2Vons","_kind":"com.palm.media.misc.file:1","_rev":316,"createdTime":1417736369,"extension":"pdf","modifiedTime":1417736369,"name":"helloworld.pdf","path":"/media/internal/helloworld.pdf","searchKey":"helloworld.pdf","size":678}]}`
