### PR TITLE
mediaindexer.service: Make sure we start only after configurator

### DIFF
--- a/files/systemd/mediaindexer.service
+++ b/files/systemd/mediaindexer.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Media indexing service
 Requires=ls-hubd_private.service ls-hubd_public.service
-After=ls-hubd_private.service ls-hubd_public.service
+After=ls-hubd_private.service ls-hubd_public.service configurator.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
On first boot we get a lot of errors in the log due to DB kinds not being available.

Sep 20 05:40:54 qemux86 mojodb-luna[554]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"org.webosports.mediaindexer","method":"delKind","payload":{"id":"com.palm.media.audio.file:1"},"error":"kind not registered: 'com.palm.media.audio.file:1'","reqErr":-3970}
Sep 20 05:40:54 qemux86 mojodb-luna[554]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"org.webosports.mediaindexer","method":"delKind","payload":{"id":"com.palm.media.misc.file:1"},"error":"kind not registered: 'com.palm.media.misc.file:1'","reqErr":-3970}
Sep 20 05:40:54 qemux86 mojodb-luna[554]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"org.webosports.mediaindexer","method":"delKind","payload":{"id":"com.palm.media.video.file:1"},"error":"kind not registered: 'com.palm.media.video.file:1'","reqErr":-3970}
Sep 20 05:40:54 qemux86 mojodb-luna[554]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"org.webosports.mediaindexer","method":"delKind","payload":{"id":"com.palm.media.playlist.file:1"},"error":"kind not registered: 'com.palm.media.playlist.file:1'","reqErr":-3970}

We need to make sure that configurator has finished before starting mediaindexer in order to avoid this.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>