### PR TITLE
MediaScannerServiceApp.cc: Add /media/internal/.cache to ignored dire…

### DIFF
--- a/src/MediaScannerServiceApp.cc
+++ b/src/MediaScannerServiceApp.cc
@@ -36,6 +36,7 @@ MediaScannerServiceApp::MediaScannerServiceApp() :
 
     ignoredDirectories.insert(THUMBNAIL_DIR);
     ignoredDirectories.insert("/media/internal/android/Android");
+    ignoredDirectories.insert("/media/internal/.cache");
 }
 
 MojErr MediaScannerServiceApp::open()


### PR DESCRIPTION
…ctories

Seems that qml creates cache files in /media/internal/.cache which are quickly removed before media indexer could actually do something with them, leading to log spam. Therefore excluding this directory from scanning.

Apr 25 08:39:24 tenderloin mediaindexer[738]: Error when adding new file: Query of file info for /media/internal/.cache/luna-next/qmlcache/1c5fe75313eeebd38b770322cd1c5bad8e822b35.qmlc.biSqlQ failed: Error when getting information for file “/media/internal/.cache/luna-next/qmlcache/1c5fe75313eeebd38b770322cd1c5bad8e822b35.qmlc.biSqlQ”: No such file or directory

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>