### PR TITLE
mediaindexer: Fix naming convention and permissions for ACG

### DIFF
--- a/files/db8/kinds/com.palm.media.audio.album
+++ b/files/db8/kinds/com.palm.media.audio.album
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.audio.album:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "indexes": [
         {
             "name": "albumname",

--- a/files/db8/kinds/com.palm.media.audio.artist
+++ b/files/db8/kinds/com.palm.media.audio.artist
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.audio.artist:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "indexes": [
         {
             "name": "artistname",

--- a/files/db8/kinds/com.palm.media.audio.file
+++ b/files/db8/kinds/com.palm.media.audio.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.audio.file:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "extends": [
         "com.palm.media.file:1"
     ],

--- a/files/db8/kinds/com.palm.media.audio.genre
+++ b/files/db8/kinds/com.palm.media.audio.genre
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.audio.genre:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "indexes": [
         {
             "name": "genrename",

--- a/files/db8/kinds/com.palm.media.file
+++ b/files/db8/kinds/com.palm.media.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.file:1",
-    "owner":"org.webosports.mediaindexer",
+    "owner":"org.webosports.service.mediaindexer",
     "extends": ["com.palm.media.types:1"],
     "indexes": [
         {

--- a/files/db8/kinds/com.palm.media.image.album
+++ b/files/db8/kinds/com.palm.media.image.album
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.image.album:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "indexes": [
         {
             "name": "path",

--- a/files/db8/kinds/com.palm.media.image.file
+++ b/files/db8/kinds/com.palm.media.image.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.image.file:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "extends": [
         "com.palm.media.file:1"
     ],

--- a/files/db8/kinds/com.palm.media.misc.file
+++ b/files/db8/kinds/com.palm.media.misc.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.misc.file:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "extends": [
         "com.palm.media.file:1"
     ],

--- a/files/db8/kinds/com.palm.media.playlist.file
+++ b/files/db8/kinds/com.palm.media.playlist.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.playlist.file:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "extends": [
         "com.palm.media.file:1"
     ],

--- a/files/db8/kinds/com.palm.media.types
+++ b/files/db8/kinds/com.palm.media.types
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.types:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "indexes": [
         {
             "name": "albumPathCreatedTimeAppCacheComplete",

--- a/files/db8/kinds/com.palm.media.video.file
+++ b/files/db8/kinds/com.palm.media.video.file
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.media.video.file:1",
-    "owner": "org.webosports.mediaindexer",
+    "owner": "org.webosports.service.mediaindexer",
     "extends": [
         "com.palm.media.file:1"
     ],

--- a/files/sysbus/org.webosports.mediaindexer.perm.json
+++ b/files/sysbus/org.webosports.mediaindexer.perm.json
@@ -1,5 +1,0 @@
-{
-    "org.webosports.service.mediaindexer": [
-        "services"
-    ]
-}

--- a/files/sysbus/org.webosports.service.mediaindexer.perm.json
+++ b/files/sysbus/org.webosports.service.mediaindexer.perm.json
@@ -1,0 +1,7 @@
+{
+    "org.webosports.service.mediaindexer": [
+        "services",
+        "database",
+        "database.internal"
+    ]
+}

--- a/files/sysbus/org.webosports.service.mediaindexer.role.json.in
+++ b/files/sysbus/org.webosports.service.mediaindexer.role.json.in
@@ -1,10 +1,10 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/mediaindexer",
     "type": "privileged",
-    "allowedNames": ["org.webosports.mediaindexer"],
+    "allowedNames": ["org.webosports.service.mediaindexer"],
     "permissions": [
         {
-            "service":"org.webosports.mediaindexer",
+            "service":"org.webosports.service.mediaindexer",
             "inbound":["*"],
             "outbound":["*"]
         }

--- a/files/sysbus/org.webosports.service.mediaindexer.service.in
+++ b/files/sysbus/org.webosports.service.mediaindexer.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
-Name=org.webosports.mediaindexer
+Name=org.webosports.service.mediaindexer
 Exec=@WEBOS_INSTALL_SBINDIR@/mediaindexer
 Type=static

--- a/files/systemd/mediaindexer.service
+++ b/files/systemd/mediaindexer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Media indexing service
+Description=LuneOS Media Indexing Service
 Requires=ls-hubd.service
 After=ls-hubd.service configurator.service
 

--- a/src/MediaScannerServiceApp.cc
+++ b/src/MediaScannerServiceApp.cc
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
     return app.main(argc, argv);
 }
 
-const char* const MediaScannerServiceApp::ServiceName = "org.webosports.mediaindexer";
+const char* const MediaScannerServiceApp::ServiceName = "org.webosports.service.mediaindexer";
 
 MediaScannerServiceApp::MediaScannerServiceApp() :
     db_client(&service),


### PR DESCRIPTION
Solves:

Jun 11 11:08:16 qemux86-64 mojodb-luna[586]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.mediaindexer","CATEGORY":"/","METHOD":"find"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>