### PR TITLE
com.palm.media.image.(album|file), com.palm.media.types: Fix permissions

### DIFF
--- a/files/db8/permissions/com.palm.media.image.album
+++ b/files/db8/permissions/com.palm.media.image.album
@@ -11,10 +11,22 @@
             "delete": "allow"
         }
     },
-	{
+    {
         "type"      : "db.kind",
         "object"    : "com.palm.media.image.album:1",
         "caller"    : "com.palm.app.photos",
+        "operations": {
+            "read"  : "allow",
+            "create": "allow",
+            "update": "allow",
+            "extend": "allow",
+            "delete": "allow"
+        }
+    },
+    {
+        "type"      : "db.kind",
+        "object"    : "com.palm.media.image.album:1",
+        "caller"    : "org.webosports.app.settings",
         "operations": {
             "read"  : "allow",
             "create": "allow",

--- a/files/db8/permissions/com.palm.media.image.file
+++ b/files/db8/permissions/com.palm.media.image.file
@@ -22,5 +22,17 @@
             "extend": "allow",
             "delete": "allow"
         }
+    },
+    {
+        "type"      : "db.kind",
+        "object"    : "com.palm.media.image.file:1",
+        "caller"    : "org.webosports.app.settings",
+        "operations": {
+            "read"  : "allow",
+            "create": "allow",
+            "update": "allow",
+            "extend": "allow",
+            "delete": "allow"
+        }
     }
 ]

--- a/files/db8/permissions/com.palm.media.types
+++ b/files/db8/permissions/com.palm.media.types
@@ -34,5 +34,17 @@
             "extend": "allow",
             "delete": "allow"
         }
+    },
+    {
+        "type"      : "db.kind",
+        "object"    : "com.palm.media.types:1",
+        "caller"    : "org.webosports.app.settings",
+        "operations": {
+            "read"  : "allow",
+            "create": "allow",
+            "update": "allow",
+            "extend": "allow",
+            "delete": "allow"
+        }
     }
 ]


### PR DESCRIPTION
Give access to org.webosports.app.settings app, so the wallpaper file picker will work.

Fixes issues such as:
2021-11-10T11:36:13.878802Z [88.180547260] kern.warning mojodb-luna [] DB8 DB_KIND_WARNING {"caller":"org.webosports.app.settings","kind":"com.palm.media.types:1"} db: permission denied for caller 'caller' on kind 'kind'

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>